### PR TITLE
fix: update service prefix name

### DIFF
--- a/runtime/jsonrpc_service.go
+++ b/runtime/jsonrpc_service.go
@@ -32,7 +32,7 @@ func (s *JsonRpcService) Run(r *http.Request, args *RunRequest, _ *RunResponse) 
 }
 
 var (
-	servicePrefix = "habiliai-agentruntime-v1"
+	servicePrefix = "habiliai-agentnetwork-v1"
 )
 
 func RegisterJsonRpcService(c *din.Container, server *rpc.Server) error {


### PR DESCRIPTION
the service prefix in the code is not aligned with README.md

## Test
- manually running CLI commands in the README.md